### PR TITLE
Add selected text for multiple selection

### DIFF
--- a/lookup-field-flow-demo/pom.xml
+++ b/lookup-field-flow-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>lookup-field-flow-demo</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
     <name>Lookup Field Demo</name>
     <packaging>war</packaging>
@@ -96,7 +96,7 @@
        <dependency>
            <groupId>com.vaadin.componentfactory</groupId>
            <artifactId>lookup-field-flow</artifactId>
-           <version>1.2.0</version>
+           <version>1.3.0</version>
        </dependency>
 
         <dependency>

--- a/lookup-field-flow-demo/src/main/java/com/vaadin/componentfactory/lookupfield/MultipleView.java
+++ b/lookup-field-flow-demo/src/main/java/com/vaadin/componentfactory/lookupfield/MultipleView.java
@@ -22,6 +22,7 @@ public class MultipleView extends Div {
         lookupField.getGrid().addColumn(s -> s).setHeader("item");
         lookupField.setLabel("Item selector");
         lookupField.addThemeVariants(EnhancedDialogVariant.SIZE_MEDIUM);
+        lookupField.showSelectedItems(true);
         add(lookupField);
     }
 

--- a/lookup-field-flow-demo/src/main/java/com/vaadin/componentfactory/lookupfield/filter/CustomFilterString.java
+++ b/lookup-field-flow-demo/src/main/java/com/vaadin/componentfactory/lookupfield/filter/CustomFilterString.java
@@ -19,6 +19,8 @@ public class CustomFilterString implements LookupFieldFilter<String> {
     private LookupFieldFilterAction<String> fieldFilterAction;
 
     public CustomFilterString() {
+        layout.setSpacing(false);
+        layout.getThemeList().add("spacing-s");
         layout.setDefaultVerticalComponentAlignment(FlexComponent.Alignment.BASELINE);
         filterField = new TextField("filter");
         layout.addAndExpand(filterField);

--- a/lookup-field-flow-demo/src/main/java/com/vaadin/componentfactory/lookupfield/service/FilteredPersonService.java
+++ b/lookup-field-flow-demo/src/main/java/com/vaadin/componentfactory/lookupfield/service/FilteredPersonService.java
@@ -5,6 +5,7 @@ import com.vaadin.componentfactory.lookupfield.bean.PersonFilter;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 public class FilteredPersonService {
@@ -26,9 +27,9 @@ public class FilteredPersonService {
             return true;
         }
         if ((StringUtils.isEmpty(filter.getLastName()) && StringUtils.isEmpty(filter.getFirstName()))) {
-            return person.toString().contains(filter.getFullName());
+            return person.toString().toLowerCase(Locale.ROOT).contains(filter.getFullName().toLowerCase(Locale.ROOT));
         } else {
-            return person.getLastName().contains(filter.getLastName()) && person.getFirstName().contains(filter.getFirstName());
+            return person.getLastName().toLowerCase(Locale.ROOT).contains(filter.getLastName().toLowerCase(Locale.ROOT)) && person.getFirstName().toLowerCase(Locale.ROOT).contains(filter.getFirstName().toLowerCase(Locale.ROOT));
         }
     }
 

--- a/lookup-field-flow/pom.xml
+++ b/lookup-field-flow/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>lookup-field-flow</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
 
     <name>Lookup Field</name>

--- a/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/AbstractLookupField.java
+++ b/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/AbstractLookupField.java
@@ -10,6 +10,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.dependency.Uses;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridMultiSelectionModel;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.notification.Notification;
@@ -36,7 +37,7 @@ import java.util.stream.Stream;
 @Uses(value = EnhancedDialog.class)
 @Tag("vcf-lookup-field")
 @JsModule("@vaadin-component-factory/vcf-lookup-field")
-@NpmPackage(value = "@vaadin-component-factory/vcf-lookup-field", version = "1.2.0")
+@NpmPackage(value = "@vaadin-component-factory/vcf-lookup-field", version = "1.3.1")
 public abstract class AbstractLookupField<T, SelectT, ComboboxT extends HasValidation & HasSize & HasFilterableDataProvider<T, String> & HasValue<?, SelectT>,
         ComponentT extends AbstractLookupField<T,SelectT, ComboboxT, ComponentT, FilterType>, FilterType> extends Div
         implements HasFilterableDataProvider<T, FilterType>,
@@ -78,6 +79,16 @@ public abstract class AbstractLookupField<T, SelectT, ComboboxT extends HasValid
         }
 
         this.grid = grid;
+        this.grid.addItemClickListener(e -> {
+            if (grid.getSelectionModel() instanceof GridMultiSelectionModel) {
+                if (!grid.getSelectedItems().contains(e.getItem())) {
+                    this.grid.deselectAll();
+                    this.grid.select(e.getItem());
+                } else {
+                    this.grid.deselectAll();
+                }
+            }
+        });
         grid.getElement().setAttribute(SLOT_KEY, GRID_SLOT_NAME);
 
         // It might already have a parent e.g when injected from a template
@@ -576,6 +587,7 @@ public abstract class AbstractLookupField<T, SelectT, ComboboxT extends HasValid
         private String search;
         private String emptyselection;
         private String create;
+        private String selectedText;
 
         public String getSearch() {
             return search;
@@ -646,6 +658,15 @@ public abstract class AbstractLookupField<T, SelectT, ComboboxT extends HasValid
 
         public LookupFieldI18n setCreate(String create) {
             this.create = create;
+            return this;
+        }
+
+        public String getSelectedText() {
+            return selectedText;
+        }
+
+        public LookupFieldI18n setSelectedText(String selectedText) {
+            this.selectedText = selectedText;
             return this;
         }
     }

--- a/lookup-field-flow/src/main/resources/META-INF/resources/frontend/lookup-dialog-overlay.css
+++ b/lookup-field-flow/src/main/resources/META-INF/resources/frontend/lookup-dialog-overlay.css
@@ -1,0 +1,10 @@
+vcf-enhanced-dialog-overlay .selected-text {
+    align-items: center;
+    box-sizing: border-box;
+    display: flex;
+    height: var(--lumo-size-m);
+    padding: 0 var(--lumo-space-m);
+    width: 100%;
+    border: 1px solid var(--lumo-contrast-20pct);
+    border-top: none;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>lookup-field-flow-root</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <packaging>pom</packaging>
     <modules>
         <module>lookup-field-flow</module>
@@ -18,7 +18,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <lookup-field-flow.version>1.2.0</lookup-field-flow.version>
+        <lookup-field-flow.version>1.3.0</lookup-field-flow.version>
     </properties>
     <inceptionYear>2020</inceptionYear>
 


### PR DESCRIPTION
Lookup dialog
- Footer is refactored to be vaadin-horizontal-layout with theme=“spacing-s”
- The dialog only closes when “Select” or “Cancel” buttons are clicked.

Number of selected items shown in the dialog  “N items selected”
Add an attribute for “has-selections” to the footer