### PR TITLE
fix: delegate required indicator so it shown in the combobox field

### DIFF
--- a/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/AbstractLookupField.java
+++ b/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/AbstractLookupField.java
@@ -404,6 +404,12 @@ public abstract class AbstractLookupField<T, SelectT, ComboboxT extends HasEnabl
         return comboBox.getErrorMessage();
     }
 
+    @Override
+    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
+        HasValueAndElement.super.setRequiredIndicatorVisible(requiredIndicatorVisible);
+        comboBox.setRequiredIndicatorVisible(requiredIndicatorVisible);
+    }
+
     /**
      * Sets the theme variants of this component. This method overwrites any
      * previous set theme variants.


### PR DESCRIPTION
The required indicator was not shown on the field when used from Flow. 

It's enough to delegate the required indicator setting to underlying combobox.

Fixes https://github.com/vaadin-component-factory/lookup-field-flow/issues/19
