### PR TITLE
Update web-component dependency to 5.0.1

### DIFF
--- a/lookup-field-flow-demo/pom.xml
+++ b/lookup-field-flow-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>lookup-field-flow-demo</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.1</version>
 
     <name>Lookup Field Demo</name>
     <packaging>war</packaging>

--- a/lookup-field-flow/pom.xml
+++ b/lookup-field-flow/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>lookup-field-flow</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.1</version>
     <packaging>jar</packaging>
 
     <name>Lookup Field</name>

--- a/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/AbstractLookupField.java
+++ b/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/AbstractLookupField.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 @Uses(value = Button.class)
 @Tag("vcf-lookup-field")
 @JsModule("@vaadin-component-factory/vcf-lookup-field")
-@NpmPackage(value = "@vaadin-component-factory/vcf-lookup-field", version = "5.0.0")
+@NpmPackage(value = "@vaadin-component-factory/vcf-lookup-field", version = "5.0.1")
 @CssImport(value = "./lookup-dialog-themes.css")
 public abstract class AbstractLookupField<T, SelectT, ComboboxT extends HasEnabled & HasValidation & HasSize & HasValue<?, SelectT>,
         ComponentT extends AbstractLookupField<T, SelectT, ComboboxT, ComponentT, FilterType>, FilterType> extends Div

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>lookup-field-flow-root</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.1</version>
     <packaging>pom</packaging>
     <modules>
         <module>lookup-field-flow</module>


### PR DESCRIPTION
Update web-component dependency to 5.0.1 to fix styling problem with integrated variant (see https://github.com/vaadin-component-factory/vcf-lookup-field/releases/tag/v5.0.1).

Component version updated to 5.0.1 to do a new release.

