### PR TITLE
Update grid selection logic so it works as expected and there's no removal of selected items in multiselect mode

### DIFF
--- a/lookup-field-flow-demo/pom.xml
+++ b/lookup-field-flow-demo/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>lookup-field-flow-demo</artifactId>
-    <version>6.0.3-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
 
     <name>Lookup Field Demo</name>
     <packaging>war</packaging>

--- a/lookup-field-flow/pom.xml
+++ b/lookup-field-flow/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>lookup-field-flow</artifactId>
-    <version>6.0.3-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Lookup Field</name>

--- a/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/AbstractLookupField.java
+++ b/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/AbstractLookupField.java
@@ -116,16 +116,6 @@ public abstract class AbstractLookupField<T, SelectT, ComboboxT extends HasEnabl
         }
 
         this.grid = grid;
-        this.grid.addItemClickListener(e -> {
-            if (grid.getSelectionModel() instanceof GridMultiSelectionModel) {
-                if (!grid.getSelectedItems().contains(e.getItem())) {
-                    this.grid.deselectAll();
-                    this.grid.select(e.getItem());
-                } else {
-                    this.grid.deselectAll();
-                }
-            }
-        });
         grid.getElement().setAttribute(SLOT_KEY, GRID_SLOT_NAME);
 
         // It might already have a parent e.g when injected from a template

--- a/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/AbstractLookupField.java
+++ b/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/AbstractLookupField.java
@@ -75,7 +75,7 @@ import tools.jackson.databind.ObjectMapper;
 @Uses(value = Button.class)
 @Tag("vcf-lookup-field")
 @JsModule("@vaadin-component-factory/vcf-lookup-field")
-@NpmPackage(value = "@vaadin-component-factory/vcf-lookup-field", version = "6.0.3")
+@NpmPackage(value = "@vaadin-component-factory/vcf-lookup-field", version = "6.1.0")
 @StyleSheet(value = "lookup-field.css")
 public abstract class AbstractLookupField<T, SelectT, ComboboxT extends HasEnabled & HasValidation & HasSize & HasValue<?, SelectT>,
         ComponentT extends AbstractLookupField<T, SelectT, ComboboxT, ComponentT, FilterType>, FilterType> extends Div

--- a/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/CustomFilterMultiSelectLookupField.java
+++ b/lookup-field-flow/src/main/java/com/vaadin/componentfactory/lookupfield/CustomFilterMultiSelectLookupField.java
@@ -83,6 +83,7 @@ public class CustomFilterMultiSelectLookupField<T, FilterType> extends AbstractL
     public void setGrid(Grid<T> grid) {
         super.setGrid(grid);
         grid.setSelectionMode(Grid.SelectionMode.MULTI);
+        getElement().setProperty("multiSelect", true);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>lookup-field-flow-root</artifactId>
-    <version>6.0.3-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>lookup-field-flow</module>


### PR DESCRIPTION
Close #30 

This PR includes the necessary updates to make grid selection to work as expected for multi select mode: 

* Update web-component version to include new multiSelect property
* Setting multiSelect property for LookupField Multiselect mode
* Removal of click listener conflicting with multiselect logic
* Update version to 6.1.0-SNAPSHOT
